### PR TITLE
Use context to manage partition consumers

### DIFF
--- a/monitor/parser.go
+++ b/monitor/parser.go
@@ -102,7 +102,7 @@ func ParseConsumerMessage(message *sarama.ConsumerMessage) (*PartitionOffset, er
 		localhost:9092 --formatter \
 		"kafka.coordinator.GroupMetadataManager\$OffsetsMessageFormatter" --from-beginning
 	*/
-	log.Debugf("[%s,%s,%d]::[OffsetMetadata[%d,NO_METADATA],CommitTime %d,ExpirationTime %d]\n",
+	log.Debugf("[%s,%s,%d]::[OffsetMetadata[%d,NO_METADATA],CommitTime %d,ExpirationTime %d]",
 		group, topic, int32(partition), int64(offset), int64(timestamp), int64(exptime))
 
 	return partitionOffset, nil

--- a/monitor/types.go
+++ b/monitor/types.go
@@ -6,17 +6,15 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/quipo/statsd"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/syncmap"
 )
 
 // QueueMonitor : Defines the type for Kafka Queue Monitor implementation.
 type QueueMonitor struct {
-	Client             sarama.Client
-	StatsdClient       *statsd.StatsdClient
-	Config             *QMConfig
-	OffsetStore        *syncmap.Map
-	PartitionConsumers *PartitionConsumers
+	Client       sarama.Client
+	StatsdClient *statsd.StatsdClient
+	Config       *QMConfig
+	OffsetStore  *syncmap.Map
 }
 
 // PartitionOffset : Defines a type for Partition Offset
@@ -39,34 +37,6 @@ func (p *PartitionOffset) String() string {
 type BrokerOffsetRequest struct {
 	Broker        *sarama.Broker
 	OffsetRequest *sarama.OffsetRequest
-}
-
-// PartitionConsumers : Wrapper around a list of sarama.PartitionConsumer
-type PartitionConsumers struct {
-	Handles []sarama.PartitionConsumer
-}
-
-// Add : Appends a partition consumer to the partition consumers list.
-func (pc *PartitionConsumers) Add(pConsumer sarama.PartitionConsumer) {
-	pc.Handles = append(pc.Handles, pConsumer)
-}
-
-// PurgeHandles : Purges all Partition Consumers (Handles) by calling
-// AsyncClose() on each of them. After doing so, it truncates the list of
-// Partition Consumers.
-func (pc *PartitionConsumers) PurgeHandles() {
-	for _, pConsumer := range pc.Handles {
-		pConsumer.AsyncClose()
-	}
-	pc.Handles = make([]sarama.PartitionConsumer, 0)
-	log.Infoln("Purged Partition Consumers.")
-}
-
-// NewPartitionConsumers : Creates a new PartitionsConsumers instance.
-func NewPartitionConsumers() *PartitionConsumers {
-	return &PartitionConsumers{
-		Handles: make([]sarama.PartitionConsumer, 0),
-	}
 }
 
 // KafkaConfig : Type for Kafka Broker Configuration.


### PR DESCRIPTION
We should manage the partition consumers created in `GetConsumerOffsers()` method with cancellable `context`s. When there is an error that occurs and is detected in the `RetryWithChannel()` function, it should call the `cancel()` on the `context` passed to the partition consumers. Each partition consumer should keep a check on the `Done` channel of the `context` passed to it. When `Done` channel returns (closes), it means that the `context` has been cancelled, usually with an error, which we should print out.

This is much cleaner than the current way of storing the partition consumers in a list, and is an idiomatic way of solving the problem using the Go's `context` API.