### PR TITLE
Update tests

### DIFF
--- a/tests/lag_test.go
+++ b/tests/lag_test.go
@@ -256,10 +256,10 @@ func TestLag(t *testing.T) {
 
 		log.Printf(`
 			##################################################################
-			Produce 10 messages and check for the lag. It should be 10 since
+			Produce %d messages and check for the lag. It should be %d since
 			the consumer hasn't consumed those messages yet.
 			##################################################################
-		`)
+		`, messageCount, messageCount)
 
 		produceMessages(messageCount)
 		lag = getConsumerLag(conn, &monitor.PartitionOffset{

--- a/tests/lag_test.go
+++ b/tests/lag_test.go
@@ -223,8 +223,6 @@ func TestLag(t *testing.T) {
 	log.Infof("Consumer Received Message on %s: %s",
 		message.TopicPartition, string(message.Value))
 
-	time.Sleep(20 * time.Second)
-
 	lag := getConsumerLag(conn, &monitor.PartitionOffset{
 		Topic:     topic,
 		Partition: partition,
@@ -248,8 +246,6 @@ func TestLag(t *testing.T) {
 			producedPartOff.Topic, producedPartOff.Partition)
 	}
 
-	time.Sleep(20 * time.Second)
-
 	lag = getConsumerLag(conn, &monitor.PartitionOffset{
 		Topic:     topic,
 		Partition: partition,
@@ -270,7 +266,7 @@ func TestLag(t *testing.T) {
 	log.Infof("Consumer Received Message on %s: %s",
 		message.TopicPartition, string(message.Value))
 
-	time.Sleep(20 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	lag = getConsumerLag(conn, &monitor.PartitionOffset{
 		Topic:     topic,


### PR DESCRIPTION
We should have a customized orchestration of Producer and Consumer in the test to check if `kqm` is monitoring the lag correctly for a given consumer.

Algorithm for verifying the lag:

1. Create a Producer
2. Produce `x` messages.
3. Create a Consumer (say Consumer A) to consume the messages. When this consumer starts consuming, `kqm` will start recognizing it (i.e. it'll add Consumer A to it's record for monitoring the lag). Close the consumer when done consuming.
4. Check the lag of Consumer A. It should be zero since it'll consume all the messages.
5. Produce some `y` messages.
6. Check the lag for Consumer A again, it should be `y` since Consumer A hasn't consumed them yet.
7. Start Consumer A now to consume the messages. Close when done.
8. Check the lag again, this time it should be zero.
9. Repeat steps 2 through 8 for different number of messages (10, 100, 1000...)

Note: We need to wait for a few seconds are the consumption of messages is initiated, so that `kqm` gets the updated information from `__consumer_offsets` and is in sync with the latest changes (~10s). Also, `kqm` should be started with a `interval` of 1s, since we want to minimize test run time.